### PR TITLE
📚 Prepare WordPress.org readme and plugin metadata

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,44 +1,60 @@
 === Markdown for AI Agents ===
 Contributors: inteligenciaartificial
-Tags: markdown, ai, agents, content, api
+Tags: markdown, ai, agents, content, export
 Requires at least: 5.0
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Serve any WordPress post or page as clean Markdown for AI agents. Just append ?format=markdown to any URL.
+Serve WordPress posts and pages as clean Markdown for AI agents and automation tools.
 
 == Description ==
 
-**Markdown for AI Agents** adds a small button at the top of every post and page that links to a Markdown version of the content. AI agents can also access the Markdown programmatically by appending `?format=markdown` to any post URL.
+Markdown for AI Agents adds a small button to singular posts and pages so visitors, crawlers, and AI agents can open a clean Markdown version of the content.
 
-The generated Markdown includes YAML frontmatter with metadata (title, author, date, categories, tags) and converts all common HTML elements to their Markdown equivalents.
+The same Markdown output is also available programmatically by appending `?format=markdown` to a post or page URL.
 
-**Features:**
+The generated Markdown includes YAML frontmatter with useful metadata and converts common HTML elements into Markdown-friendly output.
+
+Features include:
 
 * Visible "View as Markdown" button on posts and pages
-* `?format=markdown` URL parameter support
-* YAML frontmatter with post metadata
-* Full HTML-to-Markdown conversion (headings, lists, tables, code blocks, images, links, etc.)
-* Cached output for fast response times
-* Dark mode support
-* Zero external dependencies
+* `?format=markdown` endpoint for agents and automation tools
+* YAML frontmatter with title, author, date, categories, tags, and URL
+* HTML-to-Markdown conversion for headings, lists, links, images, code blocks, blockquotes, and tables
+* Cached output using WordPress transients for faster repeat requests
+* Lightweight front-end integration with no external services required
+
+Typical use cases:
+
+* AI agents that need a stable Markdown representation of a post
+* internal automation or export workflows that consume article content
+* debugging or reviewing how WordPress content is exposed outside the theme layer
 
 == Installation ==
 
-1. Upload the `wp-markdown-for-agents` folder to `/wp-content/plugins/`.
-2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. Done! The button appears automatically on all posts and pages.
+1. Upload the `wp-markdown-for-agents` folder to the `/wp-content/plugins/` directory, or install the plugin through the WordPress admin.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Open any published post or page.
+4. Click the "View as Markdown" button, or append `?format=markdown` to the URL.
 
 == Frequently Asked Questions ==
 
-= How do AI agents use this plugin? =
+= Which content types are supported? =
+
+The plugin supports singular posts and pages on the front end.
+
+= How do agents or automation tools access the Markdown output? =
 
 AI agents append `?format=markdown` to any post URL. The plugin returns the content as `text/markdown` with YAML frontmatter metadata.
 
-= Does this affect my SEO? =
+= Does this change my regular theme output? =
+
+No. The normal front-end rendering stays the same, except for the added "View as Markdown" button on singular posts and pages.
+
+= Does this affect SEO? =
 
 No. The button link uses `rel="nofollow"` and the Markdown response includes a `X-Robots-Tag: noindex` header.
 
@@ -46,7 +62,20 @@ No. The button link uses `rel="nofollow"` and the Markdown response includes a `
 
 Yes. The plugin caches the generated Markdown for 1 hour using WordPress transients. The cache is cleared automatically when you update a post.
 
+== Upgrade Notice ==
+
+= 1.0.1 =
+
+Improved WordPress.org readme content and public plugin metadata.
+
+= 1.0.0 =
+
+Initial public release.
+
 == Changelog ==
+
+= 1.0.1 =
+* Improved WordPress.org readme formatting and public metadata
 
 = 1.0.0 =
 * Initial release

--- a/wp-markdown-for-agents.php
+++ b/wp-markdown-for-agents.php
@@ -6,8 +6,8 @@
  *
  * Plugin Name:       Markdown for AI Agents
  * Plugin URI:        https://github.com/0GiS0/wp-markdown-for-agents
- * Description:       Adds a button to posts that serves content as Markdown for AI agents. Append ?format=markdown to any post URL to get the Markdown version.
- * Version:           1.0.0
+ * Description:       Serve WordPress posts and pages as clean Markdown for AI agents via a button or ?format=markdown.
+ * Version:           1.0.1
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Gisela Torres
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'MD_FOR_AGENTS_VERSION', '1.0.0' );
+define( 'MD_FOR_AGENTS_VERSION', '1.0.1' );
 define( 'MD_FOR_AGENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- improve `readme.txt` wording and sections for WordPress.org
- align public plugin metadata with the intended marketplace-facing description
- bump the plugin version to `1.0.1` for this release-facing metadata update

## Testing
- composer lint:php
- ./package-plugin.sh

Closes #1