### PR TITLE
wordpress: align plugin i18n and review package

### DIFF
--- a/includes/class-md-for-agents-button-injector.php
+++ b/includes/class-md-for-agents-button-injector.php
@@ -34,7 +34,7 @@ class MD_For_Agents_Button_Injector {
 		}
 
 		$url  = add_query_arg( 'format', 'markdown', get_permalink() );
-		$text = esc_html__( 'View as Markdown', 'md-for-agents' );
+		$text = esc_html__( 'View as Markdown', 'markdown-for-ai-agents' );
 
 		$button = sprintf(
 			'<div class="md-agent-button-wrapper">' .

--- a/package-plugin.sh
+++ b/package-plugin.sh
@@ -22,8 +22,8 @@ mkdir -p "$STAGING_DIR/$PLUGIN_DIR"
 cp -R \
   "$SCRIPT_DIR/assets" \
   "$SCRIPT_DIR/includes" \
+  "$SCRIPT_DIR/LICENSE" \
   "$SCRIPT_DIR/readme.txt" \
-  "$SCRIPT_DIR/README.md" \
   "$SCRIPT_DIR/wp-markdown-for-agents.php" \
   "$STAGING_DIR/$PLUGIN_DIR/"
 

--- a/wp-markdown-for-agents.php
+++ b/wp-markdown-for-agents.php
@@ -14,7 +14,7 @@
  * Author URI:        https://www.returngis.net
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       md-for-agents
+ * Text Domain:       markdown-for-ai-agents
  * Domain Path:       /languages
  */
 
@@ -34,6 +34,8 @@ require_once MD_FOR_AGENTS_PLUGIN_DIR . 'includes/class-md-for-agents-url-handle
  * Initialize the plugin.
  */
 function md_for_agents_init() {
+	load_plugin_textdomain( 'markdown-for-ai-agents', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
 	$converter = new MD_For_Agents_Markdown_Converter();
 	new MD_For_Agents_Button_Injector();
 	new MD_For_Agents_URL_Handler( $converter );


### PR DESCRIPTION
## Summary
- align the plugin text domain with the WordPress.org-facing slug
- load translations during plugin init
- keep the review ZIP focused on runtime files plus the license

## Validation
- composer lint:php
- ./package-plugin.sh