### PR TITLE
release: bump version to 1.0.2

### DIFF
--- a/markdown-for-ai-agents.php
+++ b/markdown-for-ai-agents.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Markdown for AI Agents
  * Plugin URI:        https://github.com/0GiS0/wp-markdown-for-agents
  * Description:       Serve WordPress posts and pages as clean Markdown for AI agents via a button or ?format=markdown.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Gisela Torres
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'MD_FOR_AGENTS_VERSION', '1.0.1' );
+define( 'MD_FOR_AGENTS_VERSION', '1.0.2' );
 define( 'MD_FOR_AGENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: markdown, ai, agents, content, export
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ Yes. The plugin caches the generated Markdown for 1 hour using WordPress transie
 
 == Upgrade Notice ==
 
+= 1.0.2 =
+
+Aligned the distributed plugin slug and WordPress.org assets, and improved local validation for Plugin Check.
+
 = 1.0.1 =
 
 Improved WordPress.org readme content and public plugin metadata.
@@ -73,6 +77,11 @@ Improved WordPress.org readme content and public plugin metadata.
 Initial public release.
 
 == Changelog ==
+
+= 1.0.2 =
+* aligned the distributed plugin slug with `markdown-for-ai-agents`
+* removed WordPress.org Plugin Check warnings from the plugin bootstrap
+* added Plugin Check support and SVG-to-PNG tooling to the dev container workflow
 
 = 1.0.1 =
 * Improved WordPress.org readme formatting and public metadata


### PR DESCRIPTION
## Summary

- bump the plugin version to 1.0.2 in the main plugin bootstrap
- update the WordPress.org stable tag, upgrade notice, and changelog entries for 1.0.2

## Validation

- composer lint:php
- ./package-plugin.sh