### PR TITLE
🧪 Improve devcontainer bootstrap and Bash checks

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ..:/workspaces/wp-markdown-for-agents:cached
+      - ..:/workspaces/markdown-view-for-ai-agents:cached
       - composer-cache:/home/vscode/.composer/cache
       - wordpress-data:/srv/wordpress
       - plugins:/home/vscode/.local/share/plugins

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 		"wordpress",
 		"db"
 	],
-	"workspaceFolder": "/workspaces/wp-markdown-for-agents",
+	"workspaceFolder": "/workspaces/markdown-view-for-ai-agents",
+	"remoteUser": "vscode",
 	"shutdownAction": "stopCompose",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -51,7 +52,8 @@
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-extra/features/shellcheck:1": {}
 	}
 
 }

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,22 +1,78 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
-wp_path="/srv/wordpress"
-site_url="http://localhost:8080"
+wp_path="${WP_PATH:-/srv/wordpress}"
+site_url="${SITE_URL:-http://localhost:8080}"
+site_title="${WORDPRESS_SITE_TITLE:-Markdown View for AI Agents}"
+admin_user="${WORDPRESS_ADMIN_USER:-admin}"
+admin_password="${WORDPRESS_ADMIN_PASSWORD:-admin}"
+admin_email="${WORDPRESS_ADMIN_EMAIL:-admin@example.com}"
 sample_seed_option="md_for_agents_sample_content_seeded"
-plugin_check_dir="/home/vscode/.local/share/plugins/plugin-check"
+plugin_check_dir="${PLUGIN_CHECK_DIR:-/home/vscode/.local/share/plugins/plugin-check}"
 plugin_check_main_file="$plugin_check_dir/plugin-check.php"
 plugin_check_cli_file="$plugin_check_dir/cli.php"
+max_attempts="${BOOTSTRAP_MAX_ATTEMPTS:-30}"
+retry_delay_seconds="${BOOTSTRAP_RETRY_DELAY_SECONDS:-2}"
 
 export XDEBUG_MODE=off
 
+log() {
+	echo "[post-start] $*"
+}
+
 wp_cli() {
+	# Keep the WordPress path in one place for every WP-CLI call.
 	wp --path="$wp_path" "$@"
 }
 
+retry_until() {
+	# Retry transient bootstrap steps while MySQL and WordPress volumes come up.
+	local attempt=1
+	local max_retries="$1"
+	local delay_seconds="$2"
+	shift 2
+
+	while [ "$attempt" -le "$max_retries" ]; do
+		if "$@"; then
+			return 0
+		fi
+		sleep "$delay_seconds"
+		attempt=$((attempt + 1))
+	done
+
+	return 1
+	}
+
+ensure_writable_dir() {
+	# The shared plugins volume may be owned by another container user on first boot.
+	local target_dir="$1"
+	local current_user
+	local current_group
+
+	current_user="$(id -un)"
+	current_group="$(id -gn)"
+
+	if mkdir -p "$target_dir" 2>/dev/null; then
+		return 0
+	fi
+
+	if ! command -v sudo >/dev/null 2>&1; then
+		echo "Cannot create $target_dir and sudo is unavailable." >&2
+		exit 1
+	fi
+
+	sudo mkdir -p "$target_dir"
+	sudo chown -R "$current_user:$current_group" "$target_dir"
+}
+
 ensure_plugin_check_files() {
-	mkdir -p "$plugin_check_dir"
+	# Plugin Check is stored on the shared plugins volume so WP-CLI can load its CLI file.
+	local tmp_dir
+	local archive
+	local extracted_dir
+
+	ensure_writable_dir "$plugin_check_dir"
 
 	if [ -f "$plugin_check_main_file" ] && [ -f "$plugin_check_cli_file" ]; then
 		return 0
@@ -25,6 +81,8 @@ ensure_plugin_check_files() {
 	tmp_dir="$(mktemp -d)"
 	archive="$tmp_dir/plugin-check.zip"
 	extracted_dir="$tmp_dir/plugin-check"
+
+	log "📦 Installing plugin-check into $plugin_check_dir"
 
 	cleanup_plugin_check_tmp() {
 		rm -rf "$tmp_dir"
@@ -43,10 +101,12 @@ ensure_plugin_check_files() {
 }
 
 upsert_post() {
-	post_type="$1"
-	post_slug="$2"
-	post_title="$3"
-	post_content="$4"
+	# Reuse the same helper for create-or-update behavior so seeding stays idempotent.
+	local post_type="$1"
+	local post_slug="$2"
+	local post_title="$3"
+	local post_content="$4"
+	local post_id
 
 	post_id="$(wp_cli post list --post_type="$post_type" --name="$post_slug" --field=ID 2>/dev/null | head -n 1 || true)"
 
@@ -69,9 +129,11 @@ upsert_post() {
 }
 
 set_post_terms() {
-	post_slug="$1"
-	taxonomy="$2"
-	terms_csv="$3"
+	# Taxonomies are assigned after creation to keep content payloads easier to read.
+	local post_slug="$1"
+	local taxonomy="$2"
+	local terms_csv="$3"
+	local post_id
 
 	post_id="$(wp_cli post list --post_type=post --name="$post_slug" --field=ID 2>/dev/null | head -n 1 || true)"
 
@@ -83,6 +145,14 @@ set_post_terms() {
 }
 
 seed_sample_content() {
+	# Seed a predictable content set that exercises the plugin's markdown conversion paths.
+	local getting_started_page_id
+	local hello_world_id
+	local sample_page_id
+	local privacy_policy_id
+
+	log "🌱 Seeding demo content"
+
 	getting_started_page_id="$(upsert_post \
 		page \
 		getting-started-markdown-agents \
@@ -162,23 +232,14 @@ wp option get siteurl --path=/srv/wordpress</code></pre><!-- /wp:code --><!-- wp
 	fi
 }
 
-if [ ! -d "$wp_path" ]; then
-	exit 0
-fi
-
-attempt=1
-max_attempts=30
-
-while [ "$attempt" -le "$max_attempts" ]; do
+ensure_wp_config() {
+	# Create wp-config.php on demand for a fresh local database.
 	if [ -f "$wp_path/wp-config.php" ]; then
-		break
+		return 0
 	fi
-	sleep 2
-	attempt=$((attempt + 1))
-done
 
-if [ ! -f "$wp_path/wp-config.php" ]; then
 	if [ -n "${WORDPRESS_DB_HOST:-}" ] && [ -n "${WORDPRESS_DB_NAME:-}" ] && [ -n "${WORDPRESS_DB_USER:-}" ] && [ -n "${WORDPRESS_DB_PASSWORD:-}" ]; then
+		log "📝 Creating wp-config.php"
 		wp config create \
 			--path="$wp_path" \
 			--dbname="$WORDPRESS_DB_NAME" \
@@ -189,43 +250,46 @@ if [ ! -f "$wp_path/wp-config.php" ]; then
 			--force >/dev/null 2>&1 || true
 	fi
 
-	if [ ! -f "$wp_path/wp-config.php" ]; then
-		echo "WordPress config is not ready yet; skipping local bootstrap."
-		exit 0
+	[ -f "$wp_path/wp-config.php" ]
+}
+
+ensure_wordpress_installed() {
+	# Install WordPress once the database accepts connections.
+	if wp_cli core is-installed >/dev/null 2>&1; then
+		return 0
 	fi
+
+	log "🚀 Installing WordPress"
+	wp_cli core install \
+		--url="$site_url" \
+		--title="$site_title" \
+		--admin_user="$admin_user" \
+		--admin_password="$admin_password" \
+		--admin_email="$admin_email" \
+		--skip-email >/dev/null 2>&1
+}
+
+if [ ! -d "$wp_path" ]; then
+	exit 0
 fi
 
-installed=0
-attempt=1
+# Wait for the mounted WordPress root and generated config to become usable.
+if ! retry_until "$max_attempts" "$retry_delay_seconds" ensure_wp_config; then
+	log "⏭️ WordPress config is not ready yet; skipping local bootstrap."
+	exit 0
+fi
 
-while [ "$attempt" -le "$max_attempts" ]; do
-	if wp_cli core is-installed >/dev/null 2>&1; then
-		installed=1
-		break
-	fi
-
-	if wp_cli core install \
-		--url="$site_url" \
-		--title="Markdown View for AI Agents" \
-		--admin_user="admin" \
-		--admin_password="admin" \
-		--admin_email="admin@example.com" \
-		--skip-email >/dev/null 2>&1; then
-		installed=1
-		break
-	fi
-
-	sleep 2
-	attempt=$((attempt + 1))
-done
-
-if [ "$installed" -eq 0 ]; then
-	echo "WordPress database bootstrap is not ready yet; skipping local site installation."
+# Install the site after config exists and the database is actually ready.
+if ! retry_until "$max_attempts" "$retry_delay_seconds" ensure_wordpress_installed; then
+	log "⏭️ WordPress database bootstrap is not ready yet; skipping local site installation."
 	exit 0
 fi
 
 ensure_plugin_check_files
 
+log "⚙️ Configuring local WordPress site"
+
+# Keep local URLs stable and activate the tools this repository expects.
 wp_cli option update blog_public 0 >/dev/null 2>&1 || true
 wp_cli rewrite structure '/%postname%/' >/dev/null 2>&1 || true
 wp_cli rewrite flush --hard >/dev/null 2>&1 || true

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,22 +7,22 @@ if ! command -v php >/dev/null 2>&1; then
   exit 0
 fi
 
-staged_php_files="$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.php$' || true)"
+mapfile -t staged_php_files < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.php$' || true)
 
-if [[ -z "$staged_php_files" ]]; then
+if [[ ${#staged_php_files[@]} -eq 0 ]]; then
   echo "No staged PHP files."
   exit 0
 fi
 
 echo "Running PHP syntax checks on staged files..."
-while IFS= read -r file; do
+for file in "${staged_php_files[@]}"; do
   [[ -z "$file" ]] && continue
   php -l "$file" >/dev/null
-done <<< "$staged_php_files"
+done
 
 if [[ -x "vendor/bin/phpcs" ]]; then
   echo "Running PHPCS on staged files..."
-  vendor/bin/phpcs --standard=phpcs.xml.dist $staged_php_files
+  vendor/bin/phpcs --standard=phpcs.xml.dist "${staged_php_files[@]}"
 else
   echo "PHPCS is not installed. Run 'composer install' to enable quality and security checks."
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
   pull_request:
 
 jobs:
+  bash-quality:
+    name: "🐚 Bash quality"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "📥 Check out repository"
+        uses: actions/checkout@v6
+
+      - name: "🛠️ Install ShellCheck"
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: "🔎 Validate Bash syntax"
+        run: |
+          bash -n .devcontainer/post-start.sh
+          bash -n install-git-hooks.sh
+          bash -n package-plugin.sh
+          bash -n .githooks/pre-commit
+
+      - name: "🐚 Run ShellCheck"
+        run: shellcheck .devcontainer/post-start.sh install-git-hooks.sh package-plugin.sh .githooks/pre-commit
+
   php-lint:
     name: "🐘 PHP ${{ matrix.php-version }} lint"
     runs-on: ubuntu-latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,6 +48,19 @@
       "group": "test"
     },
     {
+      "label": "lint bash",
+      "type": "shell",
+      "command": "shellcheck",
+      "args": [
+        ".devcontainer/post-start.sh",
+        "install-git-hooks.sh",
+        "package-plugin.sh",
+        ".githooks/pre-commit"
+      ],
+      "problemMatcher": [],
+      "group": "test"
+    },
+    {
       "label": "lint all",
       "type": "shell",
       "command": "composer",

--- a/assets/css/md-agent-admin.css
+++ b/assets/css/md-agent-admin.css
@@ -1,0 +1,61 @@
+/**
+ * Markdown View for AI Agents - Admin settings styles
+ *
+ * Layout and preview panel for the plugin settings page.
+ */
+
+.md-agent-admin-layout {
+	display: flex;
+	gap: 2em;
+	align-items: flex-start;
+	margin-top: 1em;
+}
+
+.md-agent-admin-form {
+	flex: 1;
+	min-width: 0;
+}
+
+.md-agent-admin-preview-panel {
+	flex: 0 0 320px;
+	position: sticky;
+	top: 40px;
+}
+
+.md-agent-admin-preview-panel h2 {
+	margin-top: 0;
+	font-size: 1.1em;
+}
+
+.md-agent-admin-preview-area {
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	padding: 1.5em;
+	min-height: 80px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+#md-agent-preview-container .md-agent-button-wrapper {
+	margin-bottom: 0;
+}
+
+.md-agent-admin-preview-hidden {
+	color: #666;
+	font-style: italic;
+	text-align: center;
+}
+
+@media screen and (max-width: 960px) {
+	.md-agent-admin-layout {
+		flex-direction: column;
+	}
+
+	.md-agent-admin-preview-panel {
+		flex: none;
+		width: 100%;
+		position: static;
+	}
+}

--- a/assets/js/md-agent-admin-preview.js
+++ b/assets/js/md-agent-admin-preview.js
@@ -1,0 +1,107 @@
+/**
+ * Markdown View for AI Agents - Admin live preview
+ *
+ * Updates the button preview in real-time as the user
+ * changes settings on the admin page.
+ */
+
+/* global mdForAgentsAdmin */
+
+( function () {
+	'use strict';
+
+	var ICON_SVG =
+		'<svg class="md-agent-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ' +
+		'width="16" height="16" fill="currentColor" aria-hidden="true">' +
+		'<path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 ' +
+		'13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3zM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 ' +
+		'1.92L7 8v3zm2.99.5L14.5 8H13V5h-2v3H9.5z"/></svg>';
+
+	var HIDDEN_HTML =
+		'<p class="md-agent-admin-preview-hidden">The button is hidden.<br>The <code>?format=markdown</code> endpoint remains active.</p>';
+
+	/**
+	 * Gather current field values.
+	 */
+	function getValues() {
+		var textInput    = document.getElementById( 'md_for_agents_button_text' );
+		var iconCheckbox = document.getElementById( 'md_for_agents_show_icon' );
+		var classesInput = document.getElementById( 'md_for_agents_custom_css_classes' );
+		var positionSelect = document.getElementById( 'md_for_agents_button_position' );
+
+		return {
+			text:     textInput ? textInput.value : '',
+			showIcon: iconCheckbox ? iconCheckbox.checked : true,
+			classes:  classesInput ? classesInput.value.trim() : '',
+			position: positionSelect ? positionSelect.value : 'before',
+		};
+	}
+
+	/**
+	 * Build the preview HTML from current field values.
+	 */
+	function buildPreview( values ) {
+		if ( values.position === 'none' ) {
+			return HIDDEN_HTML;
+		}
+
+		var buttonText = values.text || mdForAgentsAdmin.defaultButtonText;
+		var extraClass = values.classes ? ' ' + values.classes : '';
+		var iconHtml   = values.showIcon ? ICON_SVG + ' ' : '';
+
+		return (
+			'<div class="md-agent-button-wrapper">' +
+				'<a href="#" class="md-agent-button' + extraClass + '" rel="nofollow" onclick="return false;">' +
+					iconHtml +
+					'<span class="md-agent-button-label">' + escapeHtml( buttonText ) + '</span>' +
+				'</a>' +
+			'</div>'
+		);
+	}
+
+	/**
+	 * Minimal HTML escaping.
+	 */
+	function escapeHtml( str ) {
+		var div       = document.createElement( 'div' );
+		div.appendChild( document.createTextNode( str ) );
+		return div.innerHTML;
+	}
+
+	/**
+	 * Re-render the preview container.
+	 */
+	function updatePreview() {
+		var container = document.getElementById( 'md-agent-preview-container' );
+		if ( ! container ) {
+			return;
+		}
+		container.innerHTML = buildPreview( getValues() );
+	}
+
+	/**
+	 * Attach listeners to the settings fields.
+	 */
+	function init() {
+		var ids = [
+			'md_for_agents_button_text',
+			'md_for_agents_show_icon',
+			'md_for_agents_custom_css_classes',
+			'md_for_agents_button_position',
+		];
+
+		ids.forEach( function ( id ) {
+			var el = document.getElementById( id );
+			if ( el ) {
+				el.addEventListener( 'input', updatePreview );
+				el.addEventListener( 'change', updatePreview );
+			}
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,6 +34,14 @@ wp post list --post_type=post,page --fields=ID,post_type,post_title,post_status 
 
 PHP auto-format on save is disabled in the dev container because Intelephense formatting conflicts with the repository WPCS ruleset. Use the `fix php style` VS Code task or run `vendor/bin/phpcbf --standard=phpcs.xml.dist` when you want to apply style fixes.
 
+Bash scripts can be checked locally with ShellCheck:
+
+```bash
+shellcheck .devcontainer/post-start.sh install-git-hooks.sh package-plugin.sh .githooks/pre-commit
+```
+
+There is also a `lint bash` VS Code task for the same check.
+
 Install the PHP development tools:
 
 ```bash
@@ -53,6 +61,7 @@ The pre-commit hook will:
 
 ## GitHub Actions
 
+- `🐚 Bash quality` runs `bash -n` and `shellcheck` on repository shell scripts
 - `🧪 CI` runs PHP syntax checks, PHPCS quality checks, and packaging
 - `🔐 Dependency Review` reviews dependency changes in pull requests
 

--- a/includes/class-md-for-agents-admin-settings.php
+++ b/includes/class-md-for-agents-admin-settings.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * Admin settings page for the Markdown View for AI Agents plugin.
+ *
+ * @package MD_For_Agents
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers a settings page under Settings → Markdown View.
+ */
+class MD_For_Agents_Admin_Settings {
+
+	/**
+	 * Option name used in the wp_options table.
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'md_for_agents_settings';
+
+	/**
+	 * Settings page slug.
+	 *
+	 * @var string
+	 */
+	const PAGE_SLUG = 'md-for-agents';
+
+	/**
+	 * Default settings values.
+	 *
+	 * @var array
+	 */
+	const DEFAULTS = array(
+		'button_text'        => '',
+		'show_icon'          => '1',
+		'custom_css_classes' => '',
+		'button_position'    => 'before',
+	);
+
+	/**
+	 * Register admin hooks.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+	}
+
+	/**
+	 * Add the settings page under the Settings menu.
+	 */
+	public function add_settings_page() {
+		add_options_page(
+			__( 'Markdown View for AI Agents', 'markdown-view-for-ai-agents' ),
+			__( 'Markdown View', 'markdown-view-for-ai-agents' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Register settings, sections, and fields.
+	 */
+	public function register_settings() {
+		register_setting(
+			self::PAGE_SLUG,
+			self::OPTION_NAME,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				'default'           => self::DEFAULTS,
+			)
+		);
+
+		add_settings_section(
+			'md_for_agents_button_section',
+			__( 'Button settings', 'markdown-view-for-ai-agents' ),
+			'__return_null',
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'button_text',
+			__( 'Button text', 'markdown-view-for-ai-agents' ),
+			array( $this, 'render_button_text_field' ),
+			self::PAGE_SLUG,
+			'md_for_agents_button_section'
+		);
+
+		add_settings_field(
+			'show_icon',
+			__( 'Show icon', 'markdown-view-for-ai-agents' ),
+			array( $this, 'render_show_icon_field' ),
+			self::PAGE_SLUG,
+			'md_for_agents_button_section'
+		);
+
+		add_settings_field(
+			'custom_css_classes',
+			__( 'Custom CSS classes', 'markdown-view-for-ai-agents' ),
+			array( $this, 'render_custom_css_classes_field' ),
+			self::PAGE_SLUG,
+			'md_for_agents_button_section'
+		);
+
+		add_settings_field(
+			'button_position',
+			__( 'Button position', 'markdown-view-for-ai-agents' ),
+			array( $this, 'render_button_position_field' ),
+			self::PAGE_SLUG,
+			'md_for_agents_button_section'
+		);
+	}
+
+	/**
+	 * Sanitize the settings before saving.
+	 *
+	 * @param array $input Raw input from the settings form.
+	 * @return array Sanitized settings.
+	 */
+	public function sanitize_settings( $input ) {
+		$sanitized = array();
+
+		$sanitized['button_text'] = isset( $input['button_text'] )
+			? sanitize_text_field( $input['button_text'] )
+			: '';
+
+		$sanitized['show_icon'] = ! empty( $input['show_icon'] ) ? '1' : '0';
+
+		$sanitized['custom_css_classes'] = isset( $input['custom_css_classes'] )
+			? sanitize_text_field( $input['custom_css_classes'] )
+			: '';
+
+		$valid_positions              = array( 'before', 'after', 'both', 'none' );
+		$sanitized['button_position'] = isset( $input['button_position'] ) && in_array( $input['button_position'], $valid_positions, true )
+			? $input['button_position']
+			: 'before';
+
+		return $sanitized;
+	}
+
+	/**
+	 * Return the current settings merged with defaults.
+	 *
+	 * @return array
+	 */
+	public static function get_settings() {
+		$saved = get_option( self::OPTION_NAME, array() );
+		return wp_parse_args( $saved, self::DEFAULTS );
+	}
+
+	/**
+	 * Enqueue CSS and JS only on this plugin's settings page.
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
+	 */
+	public function enqueue_admin_assets( $hook_suffix ) {
+		if ( 'settings_page_' . self::PAGE_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'md-agent-button',
+			MD_FOR_AGENTS_PLUGIN_URL . 'assets/css/md-agent-button.css',
+			array(),
+			MD_FOR_AGENTS_VERSION
+		);
+
+		wp_enqueue_style(
+			'md-agent-admin',
+			MD_FOR_AGENTS_PLUGIN_URL . 'assets/css/md-agent-admin.css',
+			array( 'md-agent-button' ),
+			MD_FOR_AGENTS_VERSION
+		);
+
+		wp_enqueue_script(
+			'md-agent-admin-preview',
+			MD_FOR_AGENTS_PLUGIN_URL . 'assets/js/md-agent-admin-preview.js',
+			array(),
+			MD_FOR_AGENTS_VERSION,
+			true
+		);
+
+		$settings = self::get_settings();
+
+		wp_localize_script(
+			'md-agent-admin-preview',
+			'mdForAgentsAdmin',
+			array(
+				'defaultButtonText' => esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' ),
+				'currentSettings'   => $settings,
+			)
+		);
+	}
+
+	/**
+	 * Render the main settings page.
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$settings     = self::get_settings();
+		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		$button_text  = ! empty( $settings['button_text'] ) ? $settings['button_text'] : $default_text;
+		$show_icon    = '1' === $settings['show_icon'];
+		$css_classes  = $settings['custom_css_classes'];
+
+		$extra_classes = '';
+		if ( ! empty( $css_classes ) ) {
+			$extra_classes = ' ' . esc_attr( $css_classes );
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<div class="md-agent-admin-layout">
+				<div class="md-agent-admin-form">
+					<form action="options.php" method="post">
+						<?php
+						settings_fields( self::PAGE_SLUG );
+						do_settings_sections( self::PAGE_SLUG );
+						submit_button();
+						?>
+					</form>
+				</div>
+
+				<div class="md-agent-admin-preview-panel">
+					<h2><?php esc_html_e( 'Preview', 'markdown-view-for-ai-agents' ); ?></h2>
+					<div class="md-agent-admin-preview-area">
+						<div id="md-agent-preview-container">
+							<div class="md-agent-button-wrapper">
+								<a href="#" class="md-agent-button<?php echo esc_attr( $extra_classes ); ?>" rel="nofollow" onclick="return false;">
+									<?php if ( $show_icon ) : ?>
+										<svg class="md-agent-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+											<path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3zM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 1.92L7 8v3zm2.99.5L14.5 8H13V5h-2v3H9.5z"/>
+										</svg>
+									<?php endif; ?>
+									<span class="md-agent-button-label"><?php echo esc_html( $button_text ); ?></span>
+								</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the button text field.
+	 */
+	public function render_button_text_field() {
+		$settings     = self::get_settings();
+		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		?>
+		<input
+			type="text"
+			id="md_for_agents_button_text"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[button_text]"
+			value="<?php echo esc_attr( $settings['button_text'] ); ?>"
+			placeholder="<?php echo esc_attr( $default_text ); ?>"
+			class="regular-text"
+		/>
+		<p class="description">
+			<?php
+			printf(
+				/* translators: %s: default button text */
+				esc_html__( 'Leave empty to use the default text: "%s".', 'markdown-view-for-ai-agents' ),
+				esc_html( $default_text )
+			);
+			?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the show icon checkbox field.
+	 */
+	public function render_show_icon_field() {
+		$settings = self::get_settings();
+		?>
+		<label for="md_for_agents_show_icon">
+			<input
+				type="checkbox"
+				id="md_for_agents_show_icon"
+				name="<?php echo esc_attr( self::OPTION_NAME ); ?>[show_icon]"
+				value="1"
+				<?php checked( '1', $settings['show_icon'] ); ?>
+			/>
+			<?php esc_html_e( 'Display the Markdown icon next to the button text.', 'markdown-view-for-ai-agents' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Render the custom CSS classes field.
+	 */
+	public function render_custom_css_classes_field() {
+		$settings = self::get_settings();
+		?>
+		<input
+			type="text"
+			id="md_for_agents_custom_css_classes"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[custom_css_classes]"
+			value="<?php echo esc_attr( $settings['custom_css_classes'] ); ?>"
+			placeholder="my-class another-class"
+			class="regular-text"
+		/>
+		<p class="description">
+			<?php esc_html_e( 'Space-separated CSS classes to add to the button element.', 'markdown-view-for-ai-agents' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the button position select field.
+	 */
+	public function render_button_position_field() {
+		$settings = self::get_settings();
+		$options  = array(
+			'before' => __( 'Before the content', 'markdown-view-for-ai-agents' ),
+			'after'  => __( 'After the content', 'markdown-view-for-ai-agents' ),
+			'both'   => __( 'Before and after the content', 'markdown-view-for-ai-agents' ),
+			'none'   => __( 'Hidden (endpoint only)', 'markdown-view-for-ai-agents' ),
+		);
+		?>
+		<select
+			id="md_for_agents_button_position"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[button_position]"
+		>
+			<?php foreach ( $options as $value => $label ) : ?>
+				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $settings['button_position'], $value ); ?>>
+					<?php echo esc_html( $label ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<p class="description">
+			<?php esc_html_e( 'Choose where the button appears relative to the post content. "Hidden" keeps the ?format=markdown endpoint active without showing any button.', 'markdown-view-for-ai-agents' ); ?>
+		</p>
+		<?php
+	}
+}

--- a/includes/class-md-for-agents-button-injector.php
+++ b/includes/class-md-for-agents-button-injector.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Injects a "View as Markdown" button at the top of single posts and pages.
+ * Injects a "View as Markdown" button into single posts and pages.
  *
  * @package MD_For_Agents
  */
@@ -15,6 +15,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class MD_For_Agents_Button_Injector {
 
 	/**
+	 * Default SVG icon markup for the button.
+	 *
+	 * @var string
+	 */
+	const ICON_SVG = '<svg class="md-agent-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">' .
+		'<path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3zM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 1.92L7 8v3zm2.99.5L14.5 8H13V5h-2v3H9.5z"/>' .
+		'</svg>';
+
+	/**
 	 * Register button-related hooks.
 	 */
 	public function __construct() {
@@ -23,7 +32,7 @@ class MD_For_Agents_Button_Injector {
 	}
 
 	/**
-	 * Prepend the markdown button to single post/page content.
+	 * Insert the markdown button into single post/page content.
 	 *
 	 * @param string $content The post content.
 	 * @return string
@@ -33,23 +42,97 @@ class MD_For_Agents_Button_Injector {
 			return $content;
 		}
 
-		$url  = add_query_arg( 'format', 'markdown', get_permalink() );
-		$text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		$settings = MD_For_Agents_Admin_Settings::get_settings();
+
+		/**
+		 * Filter the button position relative to the post content.
+		 *
+		 * Accepted values: 'before', 'after', 'both', 'none'.
+		 *
+		 * @param string $position Current position setting.
+		 */
+		$position = apply_filters( 'md_for_agents_button_position', $settings['button_position'] );
+
+		if ( 'none' === $position ) {
+			return $content;
+		}
+
+		$button = $this->build_button_html( $settings );
+
+		switch ( $position ) {
+			case 'after':
+				return $content . $button;
+			case 'both':
+				return $button . $content . $button;
+			default:
+				return $button . $content;
+		}
+	}
+
+	/**
+	 * Build the full button HTML applying settings and filters.
+	 *
+	 * @param array $settings Plugin settings.
+	 * @return string
+	 */
+	private function build_button_html( $settings ) {
+		$url = add_query_arg( 'format', 'markdown', get_permalink() );
+
+		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+
+		/**
+		 * Filter the button text.
+		 *
+		 * @param string $text Button text.
+		 */
+		$text = apply_filters(
+			'md_for_agents_button_text',
+			! empty( $settings['button_text'] ) ? $settings['button_text'] : $default_text
+		);
+
+		/**
+		 * Filter whether to show the SVG icon.
+		 *
+		 * @param bool $show_icon Whether the icon is displayed.
+		 */
+		$show_icon = apply_filters( 'md_for_agents_button_icon', '1' === $settings['show_icon'] );
+
+		$icon_html = $show_icon ? self::ICON_SVG . ' ' : '';
+
+		$css_classes = 'md-agent-button';
+
+		if ( ! empty( $settings['custom_css_classes'] ) ) {
+			$css_classes .= ' ' . $settings['custom_css_classes'];
+		}
+
+		/**
+		 * Filter the CSS classes applied to the button element.
+		 *
+		 * @param string $css_classes Space-separated CSS classes.
+		 */
+		$css_classes = apply_filters( 'md_for_agents_button_classes', $css_classes );
 
 		$button = sprintf(
 			'<div class="md-agent-button-wrapper">' .
-				'<a href="%s" class="md-agent-button" rel="nofollow" title="%s">' .
-					'<svg class="md-agent-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">' .
-						'<path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3zM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 1.92L7 8v3zm2.99.5L14.5 8H13V5h-2v3H9.5z"/>' .
-					'</svg> %s' .
+				'<a href="%s" class="%s" rel="nofollow" title="%s">' .
+					'%s%s' .
 				'</a>' .
 			'</div>',
 			esc_url( $url ),
+			esc_attr( $css_classes ),
 			esc_attr( $text ),
-			$text
+			$icon_html,
+			esc_html( $text )
 		);
 
-		return $button . $content;
+		/**
+		 * Filter the complete button HTML.
+		 *
+		 * @param string $button The full button markup.
+		 * @param string $url    The markdown URL.
+		 * @param string $text   The button text.
+		 */
+		return apply_filters( 'md_for_agents_button_html', $button, $url, $text );
 	}
 
 	/**

--- a/markdown-view-for-ai-agents.php
+++ b/markdown-view-for-ai-agents.php
@@ -28,6 +28,7 @@ define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require_once MD_FOR_AGENTS_PLUGIN_DIR . 'includes/class-md-for-agents-markdown-converter.php';
 require_once MD_FOR_AGENTS_PLUGIN_DIR . 'includes/class-md-for-agents-button-injector.php';
 require_once MD_FOR_AGENTS_PLUGIN_DIR . 'includes/class-md-for-agents-url-handler.php';
+require_once MD_FOR_AGENTS_PLUGIN_DIR . 'includes/class-md-for-agents-admin-settings.php';
 
 /**
  * Initialize the plugin.
@@ -36,6 +37,10 @@ function md_for_agents_init() {
 	$converter = new MD_For_Agents_Markdown_Converter();
 	new MD_For_Agents_Button_Injector();
 	new MD_For_Agents_URL_Handler( $converter );
+
+	if ( is_admin() ) {
+		new MD_For_Agents_Admin_Settings();
+	}
 }
 add_action( 'init', 'md_for_agents_init' );
 


### PR DESCRIPTION
## Summary
- refactor the devcontainer post-start bootstrap for safer retries, configurability, and clearer logs
- fix shared-volume permission handling for plugin-check and add inline script comments
- add Bash validation through ShellCheck in CI and a local VS Code task
- document the local Bash checks and tighten the pre-commit hook argument handling

Closes #28

## Validation
- composer lint:php
- wp --path=/srv/wordpress plugin check markdown-view-for-ai-agents --require=/srv/wordpress/wp-content/plugins/plugin-check/cli.php --exclude-directories=.devcontainer,.github,vendor,dist --exclude-files=.gitignore,install-git-hooks.sh,package-plugin.sh,phpcs.xml.dist,AGENTS.md
- bash -n .devcontainer/post-start.sh
- bash -n install-git-hooks.sh
- bash -n package-plugin.sh
- bash -n .githooks/pre-commit
- shellcheck .devcontainer/post-start.sh install-git-hooks.sh package-plugin.sh .githooks/pre-commit