### PR TITLE
Update Tested up to header for WordPress 7.0

### DIFF
--- a/markdown-view-for-ai-agents.php
+++ b/markdown-view-for-ai-agents.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Markdown View for AI Agents
  * Plugin URI:        https://github.com/0GiS0/markdown-view-for-agents
  * Description:       Serve WordPress posts and pages as clean Markdown for AI agents via a button or ?format=markdown.
- * Version:           1.0.4
+ * Version:           1.0.5
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Gisela Torres
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'MD_FOR_AGENTS_VERSION', '1.0.4' );
+define( 'MD_FOR_AGENTS_VERSION', '1.0.5' );
 define( 'MD_FOR_AGENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: 0gis0
 Tags: markdown, ai, agents, content, export
 Requires at least: 5.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ Yes. The plugin caches the generated Markdown for 1 hour using WordPress transie
 
 == Upgrade Notice ==
 
+= 1.0.5 =
+
+Updated compatibility metadata for WordPress 7.0.
+
 = 1.0.4 =
 
 Addressed WordPress.org review feedback for contributor metadata and escaped generated Markdown output.
@@ -85,6 +89,13 @@ Improved WordPress.org readme content and public plugin metadata.
 Initial public release.
 
 == Changelog ==
+
+= 1.0.5 =
+* updated the `Tested up to` header to WordPress 7.0
+
+= 1.0.4 =
+* addressed WordPress.org review feedback for contributor metadata
+* escaped the generated Markdown output
 
 = 1.0.3 =
 * renamed the plugin to `Markdown View for AI Agents`


### PR DESCRIPTION
## Problem

The WordPress.org automated plugin scan failed:

> readme.txt [ERROR: outdated_tested_upto_header]: Tested up to: 6.9 < 7.0

`readme.txt` declared compatibility only up to WordPress 6.9, which is below the current WordPress release, so the plugin would not show up in directory searches.

## Changes

- `readme.txt`: `Tested up to: 6.9` → `7.0`
- Bumped the plugin version to `1.0.5` (patch, per SemVer: compatibility metadata fix that ships in the release artifact)
  - `Stable tag` in `readme.txt`
  - `Version:` header and `MD_FOR_AGENTS_VERSION` in `markdown-view-for-ai-agents.php`
- Added `1.0.5` entries to `== Upgrade Notice ==` and `== Changelog ==`
- Backfilled the missing `1.0.4` entry in `== Changelog ==` (it was only present under Upgrade Notice)

## Validation

Metadata-only change; no PHP logic touched. Composer/`wp` tooling is not available outside the dev container in this environment — please run `composer lint:php` and the Plugin Check task locally before merging if you want the standard gate.