### PR TITLE
Address WordPress.org review feedback: brand prefix and output escaping

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -4,12 +4,12 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ..:/workspaces/markdown-view-for-ai-agents:cached
+      - ..:/workspaces/returngis-markdown-view-for-ai-agents:cached
       - composer-cache:/home/vscode/.composer/cache
       - wordpress-data:/srv/wordpress
       - plugins:/home/vscode/.local/share/plugins
       - plugins:/srv/wordpress/wp-content/plugins
-      - ..:/srv/wordpress/wp-content/plugins/markdown-view-for-ai-agents:cached
+      - ..:/srv/wordpress/wp-content/plugins/returngis-markdown-view-for-ai-agents:cached
     environment:
       COMPOSER_MEMORY_LIMIT: -1
       WORDPRESS_DB_HOST: db:3306
@@ -34,7 +34,7 @@ services:
     volumes:
       - wordpress-data:/var/www/html
       - plugins:/var/www/html/wp-content/plugins
-      - ..:/var/www/html/wp-content/plugins/markdown-view-for-ai-agents:cached
+      - ..:/var/www/html/wp-content/plugins/returngis-markdown-view-for-ai-agents:cached
     depends_on:
       - db
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/php
 {
-	"name": "🧪 markdown-view-for-ai-agents",
+	"name": "🧪 returngis-markdown-view-for-ai-agents",
 	"dockerComposeFile": "compose.yml",
 	"service": "workspace",
 	"runServices": [
@@ -9,7 +9,7 @@
 		"wordpress",
 		"db"
 	],
-	"workspaceFolder": "/workspaces/markdown-view-for-ai-agents",
+	"workspaceFolder": "/workspaces/returngis-markdown-view-for-ai-agents",
 	"remoteUser": "vscode",
 	"shutdownAction": "stopCompose",
 

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 wp_path="${WP_PATH:-/srv/wordpress}"
 site_url="${SITE_URL:-http://localhost:8080}"
-site_title="${WORDPRESS_SITE_TITLE:-Markdown View for AI Agents}"
+site_title="${WORDPRESS_SITE_TITLE:-ReturnGIS Markdown View for AI Agents}"
 admin_user="${WORDPRESS_ADMIN_USER:-admin}"
 admin_password="${WORDPRESS_ADMIN_PASSWORD:-admin}"
 admin_email="${WORDPRESS_ADMIN_EMAIL:-admin@example.com}"
@@ -187,7 +187,7 @@ seed_sample_content() {
 		post \
 		code-blocks-and-tables \
 		'Code Blocks and Tables' \
-		"<!-- wp:paragraph --><p>This sample covers fenced code blocks and HTML tables converted into markdown tables.</p><!-- /wp:paragraph --><!-- wp:code --><pre class=\"wp-block-code\"><code lang=\"bash\">wp plugin activate markdown-view-for-ai-agents --path=/srv/wordpress
+		"<!-- wp:paragraph --><p>This sample covers fenced code blocks and HTML tables converted into markdown tables.</p><!-- /wp:paragraph --><!-- wp:code --><pre class=\"wp-block-code\"><code lang=\"bash\">wp plugin activate returngis-markdown-view-for-ai-agents --path=/srv/wordpress
 wp option get siteurl --path=/srv/wordpress</code></pre><!-- /wp:code --><!-- wp:table --><figure class=\"wp-block-table\"><table><thead><tr><th>Check</th><th>Expected result</th></tr></thead><tbody><tr><td>Code fence</td><td>Preserved with bash language</td></tr><tr><td>Table headers</td><td>Rendered as markdown table header row</td></tr></tbody></table></figure><!-- /wp:table -->" >/dev/null
 
 	upsert_post \
@@ -294,6 +294,6 @@ wp_cli option update blog_public 0 >/dev/null 2>&1 || true
 wp_cli rewrite structure '/%postname%/' >/dev/null 2>&1 || true
 wp_cli rewrite flush --hard >/dev/null 2>&1 || true
 wp_cli theme activate twentytwentythree >/dev/null 2>&1 || true
-wp_cli plugin activate markdown-view-for-ai-agents >/dev/null 2>&1 || true
+wp_cli plugin activate returngis-markdown-view-for-ai-agents >/dev/null 2>&1 || true
 wp_cli plugin activate plugin-check >/dev/null 2>&1 || true
 seed_sample_content

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,6 @@ jobs:
       - name: "⬆️ Upload plugin artifact"
         uses: actions/upload-artifact@v7
         with:
-          name: markdown-view-for-ai-agents-zip
-          path: dist/markdown-view-for-ai-agents.zip
+          name: returngis-markdown-view-for-ai-agents-zip
+          path: dist/returngis-markdown-view-for-ai-agents.zip
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,6 @@ jobs:
           body: ${{ steps.build_changelog.outputs.changelog }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          files: dist/markdown-view-for-ai-agents.zip
+          files: dist/returngis-markdown-view-for-ai-agents.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -86,7 +86,7 @@
         "--path=/srv/wordpress",
         "plugin",
         "check",
-        "markdown-view-for-ai-agents",
+        "returngis-markdown-view-for-ai-agents",
         "--require=/srv/wordpress/wp-content/plugins/plugin-check/cli.php",
         "--exclude-directories=.devcontainer,.github,vendor,dist",
         "--exclude-files=.gitignore,install-git-hooks.sh,package-plugin.sh,phpcs.xml.dist,AGENTS.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 
 - Run the relevant local checks whenever you implement or modify behavior.
 - At minimum, run `composer lint:php` before opening or updating a pull request.
-- Run the local Plugin Check validation before pushing changes or updating a pull request. Use `wp --path=/srv/wordpress plugin check markdown-view-for-ai-agents --require=/srv/wordpress/wp-content/plugins/plugin-check/cli.php --exclude-directories=.devcontainer,.github,vendor,dist --exclude-files=.gitignore,install-git-hooks.sh,package-plugin.sh,phpcs.xml.dist,AGENTS.md` or the equivalent `plugin check` VS Code task.
+- Run the local Plugin Check validation before pushing changes or updating a pull request. Use `wp --path=/srv/wordpress plugin check returngis-markdown-view-for-ai-agents --require=/srv/wordpress/wp-content/plugins/plugin-check/cli.php --exclude-directories=.devcontainer,.github,vendor,dist --exclude-files=.gitignore,install-git-hooks.sh,package-plugin.sh,phpcs.xml.dist,AGENTS.md` or the equivalent `plugin check` VS Code task.
 - Run `composer lint` when you want the repository-standard PHPCS checks.
 - If packaging, release automation, or distributable contents changed, also verify `./package-plugin.sh` or the equivalent packaging task.
 - Do not merge changes that have not been validated locally unless there is a documented reason.
@@ -42,7 +42,7 @@ If a pull request should not appear in the changelog, use `skip-changelog`.
 ## Versioning
 
 - Use SemVer for plugin versions and git tags.
-- Keep the plugin header version and the `MD_FOR_AGENTS_VERSION` constant in `markdown-view-for-ai-agents.php` aligned.
+- Keep the plugin header version and the `MD_FOR_AGENTS_VERSION` constant in `returngis-markdown-view-for-ai-agents.php` aligned.
 - Decide the version bump in every release-facing pull request.
 
 SemVer rules for this repository:
@@ -66,7 +66,7 @@ Practical rule:
 Recommended release flow:
 
 1. Merge the release-ready pull request into `main`.
-2. Confirm the plugin version in `markdown-view-for-ai-agents.php` matches the intended release version.
+2. Confirm the plugin version in `returngis-markdown-view-for-ai-agents.php` matches the intended release version.
 3. Confirm merged pull requests included in the release have exactly one changelog category label, or `skip-changelog`.
 4. Review the current WordPress.org Detailed Plugin Guidelines before generating a new release: `https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/`.
 5. Search WordPress.org for the proposed plugin name and intended slug before any marketplace-facing release or submission to avoid collisions.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Markdown View for AI Agents
+# ReturnGIS Markdown View for AI Agents
 
 <p align="center">
-  <img src=".wordpress-org/source/wp-markdown-for-agents-banner-retina.svg" alt="Markdown View for AI Agents banner" />
+  <img src=".wordpress-org/source/wp-markdown-for-agents-banner-retina.svg" alt="ReturnGIS Markdown View for AI Agents banner" />
 </p>
 
 <p align="center">
   <a href="https://github.com/0GiS0/markdown-view-for-agents/releases/latest"><img src="https://img.shields.io/github/v/release/0GiS0/markdown-view-for-agents?display_name=tag&amp;label=latest%20release" alt="Latest release" /></a>
-  <a href="https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/markdown-view-for-ai-agents.zip"><img src="https://img.shields.io/badge/download-latest%20ZIP-2ea44f?logo=github" alt="Download ZIP" /></a>
+  <a href="https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/returngis-markdown-view-for-ai-agents.zip"><img src="https://img.shields.io/badge/download-latest%20ZIP-2ea44f?logo=github" alt="Download ZIP" /></a>
   <a href="https://github.com/0GiS0/markdown-view-for-agents/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/0GiS0/markdown-view-for-agents/ci.yml?branch=main&amp;label=ci" alt="CI" /></a>
   <a href="https://wordpress.org/"><img src="https://img.shields.io/badge/WordPress-5.0%2B-21759B?logo=wordpress&amp;logoColor=white" alt="WordPress 5.0+" /></a>
   <a href="https://www.php.net/"><img src="https://img.shields.io/badge/PHP-7.4%2B-777BB4?logo=php&amp;logoColor=white" alt="PHP 7.4+" /></a>
@@ -16,7 +16,7 @@
 Turn WordPress posts and pages into clean Markdown for AI agents, automation tools, and humans. Add `?format=markdown` to any singular post or page URL and the plugin returns a Markdown response with YAML frontmatter and Markdown-friendly content.
 
 > [!TIP]
-> Want the fastest install path? Download the latest plugin package here: [markdown-view-for-ai-agents.zip](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/markdown-view-for-ai-agents.zip)
+> Want the fastest install path? Download the latest plugin package here: [returngis-markdown-view-for-ai-agents.zip](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/returngis-markdown-view-for-ai-agents.zip)
 
 This README is the GitHub landing page for releases, development, and creator links. The WordPress.org-specific plugin description stays in [readme.txt](https://github.com/0GiS0/markdown-view-for-agents/blob/main/readme.txt).
 
@@ -33,7 +33,7 @@ This README is the GitHub landing page for releases, development, and creator li
 
 This is the recommended path if you just want to use the plugin in WordPress.
 
-1. Download the latest release asset: [markdown-view-for-ai-agents.zip](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/markdown-view-for-ai-agents.zip)
+1. Download the latest release asset: [returngis-markdown-view-for-ai-agents.zip](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/returngis-markdown-view-for-ai-agents.zip)
 2. In WordPress admin, go to Plugins > Add New Plugin > Upload Plugin.
 3. Upload the ZIP file and activate the plugin.
 4. Open any published post or page and click "View as Markdown", or append `?format=markdown` to the URL.
@@ -58,7 +58,7 @@ chmod +x package-plugin.sh
 ./package-plugin.sh
 ```
 
-That creates `dist/markdown-view-for-ai-agents.zip`.
+That creates `dist/returngis-markdown-view-for-ai-agents.zip`.
 
 ## Usage
 
@@ -116,7 +116,7 @@ Article content in clean Markdown...
 ## Project links
 
 - [Latest release](https://github.com/0GiS0/markdown-view-for-agents/releases/latest)
-- [Download latest ZIP](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/markdown-view-for-ai-agents.zip)
+- [Download latest ZIP](https://github.com/0GiS0/markdown-view-for-agents/releases/latest/download/returngis-markdown-view-for-ai-agents.zip)
 - [Development guide](https://github.com/0GiS0/markdown-view-for-agents/blob/main/docs/development.md)
 - [Release workflow notes](https://github.com/0GiS0/markdown-view-for-agents/blob/main/docs/releasing.md)
 - [WordPress.org readme](https://github.com/0GiS0/markdown-view-for-agents/blob/main/readme.txt)

--- a/assets/css/md-agent-admin.css
+++ b/assets/css/md-agent-admin.css
@@ -1,5 +1,5 @@
 /**
- * Markdown View for AI Agents - Admin settings styles
+ * ReturnGIS Markdown View for AI Agents - Admin settings styles
  *
  * Layout and preview panel for the plugin settings page.
  */

--- a/assets/css/md-agent-button.css
+++ b/assets/css/md-agent-button.css
@@ -1,5 +1,5 @@
 /**
- * Markdown View for AI Agents - Button styles
+ * ReturnGIS Markdown View for AI Agents - Button styles
  *
  * Neutral design that adapts to any WordPress theme.
  */

--- a/assets/js/md-agent-admin-preview.js
+++ b/assets/js/md-agent-admin-preview.js
@@ -1,5 +1,5 @@
 /**
- * Markdown View for AI Agents - Admin live preview
+ * ReturnGIS Markdown View for AI Agents - Admin live preview
  *
  * Updates the button preview in real-time as the user
  * changes settings on the admin page.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "0gis0/markdown-view-for-agents",
-  "description": "Development tooling for the Markdown View for AI Agents WordPress plugin.",
+  "description": "Development tooling for the ReturnGIS Markdown View for AI Agents WordPress plugin.",
   "type": "project",
   "require": {},
   "require-dev": {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,12 +20,12 @@ git push origin v1.0.1
 
 When you push a matching tag, GitHub Actions will:
 
-- Build `dist/markdown-view-for-ai-agents.zip`
+- Build `dist/returngis-markdown-view-for-ai-agents.zip`
 - Build a categorized changelog from merged pull requests
 - Create a GitHub Release automatically
 - Attach the plugin ZIP to that release
 
-For consistency, keep the plugin version in `markdown-view-for-ai-agents.php` aligned with the tag you publish.
+For consistency, keep the plugin version in `returngis-markdown-view-for-ai-agents.php` aligned with the tag you publish.
 
 Before any WordPress.org submission or marketplace-facing release, search the directory for the proposed plugin name and slug to avoid collisions with existing listings.
 

--- a/includes/class-md-for-agents-admin-settings.php
+++ b/includes/class-md-for-agents-admin-settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin settings page for the Markdown View for AI Agents plugin.
+ * Admin settings page for the ReturnGIS Markdown View for AI Agents plugin.
  *
  * @package MD_For_Agents
  */
@@ -54,8 +54,8 @@ class MD_For_Agents_Admin_Settings {
 	 */
 	public function add_settings_page() {
 		add_options_page(
-			__( 'Markdown View for AI Agents', 'markdown-view-for-ai-agents' ),
-			__( 'Markdown View', 'markdown-view-for-ai-agents' ),
+			__( 'ReturnGIS Markdown View for AI Agents', 'returngis-markdown-view-for-ai-agents' ),
+			__( 'Markdown View', 'returngis-markdown-view-for-ai-agents' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_settings_page' )
@@ -78,14 +78,14 @@ class MD_For_Agents_Admin_Settings {
 
 		add_settings_section(
 			'md_for_agents_button_section',
-			__( 'Button settings', 'markdown-view-for-ai-agents' ),
+			__( 'Button settings', 'returngis-markdown-view-for-ai-agents' ),
 			'__return_null',
 			self::PAGE_SLUG
 		);
 
 		add_settings_field(
 			'button_text',
-			__( 'Button text', 'markdown-view-for-ai-agents' ),
+			__( 'Button text', 'returngis-markdown-view-for-ai-agents' ),
 			array( $this, 'render_button_text_field' ),
 			self::PAGE_SLUG,
 			'md_for_agents_button_section'
@@ -93,7 +93,7 @@ class MD_For_Agents_Admin_Settings {
 
 		add_settings_field(
 			'show_icon',
-			__( 'Show icon', 'markdown-view-for-ai-agents' ),
+			__( 'Show icon', 'returngis-markdown-view-for-ai-agents' ),
 			array( $this, 'render_show_icon_field' ),
 			self::PAGE_SLUG,
 			'md_for_agents_button_section'
@@ -101,7 +101,7 @@ class MD_For_Agents_Admin_Settings {
 
 		add_settings_field(
 			'custom_css_classes',
-			__( 'Custom CSS classes', 'markdown-view-for-ai-agents' ),
+			__( 'Custom CSS classes', 'returngis-markdown-view-for-ai-agents' ),
 			array( $this, 'render_custom_css_classes_field' ),
 			self::PAGE_SLUG,
 			'md_for_agents_button_section'
@@ -109,7 +109,7 @@ class MD_For_Agents_Admin_Settings {
 
 		add_settings_field(
 			'button_position',
-			__( 'Button position', 'markdown-view-for-ai-agents' ),
+			__( 'Button position', 'returngis-markdown-view-for-ai-agents' ),
 			array( $this, 'render_button_position_field' ),
 			self::PAGE_SLUG,
 			'md_for_agents_button_section'
@@ -191,7 +191,7 @@ class MD_For_Agents_Admin_Settings {
 			'md-agent-admin-preview',
 			'mdForAgentsAdmin',
 			array(
-				'defaultButtonText' => esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' ),
+				'defaultButtonText' => esc_html__( 'View as Markdown', 'returngis-markdown-view-for-ai-agents' ),
 				'currentSettings'   => $settings,
 			)
 		);
@@ -206,7 +206,7 @@ class MD_For_Agents_Admin_Settings {
 		}
 
 		$settings     = self::get_settings();
-		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		$default_text = esc_html__( 'View as Markdown', 'returngis-markdown-view-for-ai-agents' );
 		$button_text  = ! empty( $settings['button_text'] ) ? $settings['button_text'] : $default_text;
 		$show_icon    = '1' === $settings['show_icon'];
 		$css_classes  = $settings['custom_css_classes'];
@@ -231,7 +231,7 @@ class MD_For_Agents_Admin_Settings {
 				</div>
 
 				<div class="md-agent-admin-preview-panel">
-					<h2><?php esc_html_e( 'Preview', 'markdown-view-for-ai-agents' ); ?></h2>
+					<h2><?php esc_html_e( 'Preview', 'returngis-markdown-view-for-ai-agents' ); ?></h2>
 					<div class="md-agent-admin-preview-area">
 						<div id="md-agent-preview-container">
 							<div class="md-agent-button-wrapper">
@@ -257,7 +257,7 @@ class MD_For_Agents_Admin_Settings {
 	 */
 	public function render_button_text_field() {
 		$settings     = self::get_settings();
-		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		$default_text = esc_html__( 'View as Markdown', 'returngis-markdown-view-for-ai-agents' );
 		?>
 		<input
 			type="text"
@@ -271,7 +271,7 @@ class MD_For_Agents_Admin_Settings {
 			<?php
 			printf(
 				/* translators: %s: default button text */
-				esc_html__( 'Leave empty to use the default text: "%s".', 'markdown-view-for-ai-agents' ),
+				esc_html__( 'Leave empty to use the default text: "%s".', 'returngis-markdown-view-for-ai-agents' ),
 				esc_html( $default_text )
 			);
 			?>
@@ -293,7 +293,7 @@ class MD_For_Agents_Admin_Settings {
 				value="1"
 				<?php checked( '1', $settings['show_icon'] ); ?>
 			/>
-			<?php esc_html_e( 'Display the Markdown icon next to the button text.', 'markdown-view-for-ai-agents' ); ?>
+			<?php esc_html_e( 'Display the Markdown icon next to the button text.', 'returngis-markdown-view-for-ai-agents' ); ?>
 		</label>
 		<?php
 	}
@@ -313,7 +313,7 @@ class MD_For_Agents_Admin_Settings {
 			class="regular-text"
 		/>
 		<p class="description">
-			<?php esc_html_e( 'Space-separated CSS classes to add to the button element.', 'markdown-view-for-ai-agents' ); ?>
+			<?php esc_html_e( 'Space-separated CSS classes to add to the button element.', 'returngis-markdown-view-for-ai-agents' ); ?>
 		</p>
 		<?php
 	}
@@ -324,10 +324,10 @@ class MD_For_Agents_Admin_Settings {
 	public function render_button_position_field() {
 		$settings = self::get_settings();
 		$options  = array(
-			'before' => __( 'Before the content', 'markdown-view-for-ai-agents' ),
-			'after'  => __( 'After the content', 'markdown-view-for-ai-agents' ),
-			'both'   => __( 'Before and after the content', 'markdown-view-for-ai-agents' ),
-			'none'   => __( 'Hidden (endpoint only)', 'markdown-view-for-ai-agents' ),
+			'before' => __( 'Before the content', 'returngis-markdown-view-for-ai-agents' ),
+			'after'  => __( 'After the content', 'returngis-markdown-view-for-ai-agents' ),
+			'both'   => __( 'Before and after the content', 'returngis-markdown-view-for-ai-agents' ),
+			'none'   => __( 'Hidden (endpoint only)', 'returngis-markdown-view-for-ai-agents' ),
 		);
 		?>
 		<select
@@ -341,7 +341,7 @@ class MD_For_Agents_Admin_Settings {
 			<?php endforeach; ?>
 		</select>
 		<p class="description">
-			<?php esc_html_e( 'Choose where the button appears relative to the post content. "Hidden" keeps the ?format=markdown endpoint active without showing any button.', 'markdown-view-for-ai-agents' ); ?>
+			<?php esc_html_e( 'Choose where the button appears relative to the post content. "Hidden" keeps the ?format=markdown endpoint active without showing any button.', 'returngis-markdown-view-for-ai-agents' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/class-md-for-agents-button-injector.php
+++ b/includes/class-md-for-agents-button-injector.php
@@ -78,7 +78,7 @@ class MD_For_Agents_Button_Injector {
 	private function build_button_html( $settings ) {
 		$url = add_query_arg( 'format', 'markdown', get_permalink() );
 
-		$default_text = esc_html__( 'View as Markdown', 'markdown-view-for-ai-agents' );
+		$default_text = esc_html__( 'View as Markdown', 'returngis-markdown-view-for-ai-agents' );
 
 		/**
 		 * Filter the button text.
@@ -132,7 +132,48 @@ class MD_For_Agents_Button_Injector {
 		 * @param string $url    The markdown URL.
 		 * @param string $text   The button text.
 		 */
-		return apply_filters( 'md_for_agents_button_html', $button, $url, $text );
+		$button = apply_filters( 'md_for_agents_button_html', $button, $url, $text );
+
+		return wp_kses( $button, $this->get_allowed_button_tags() );
+	}
+
+	/**
+	 * Return the allowed HTML tags and attributes for the injected button markup.
+	 *
+	 * @return array<string, array<string, bool>>
+	 */
+	private function get_allowed_button_tags() {
+		return array(
+			'div'  => array(
+				'class' => true,
+				'id'    => true,
+			),
+			'a'    => array(
+				'href'   => true,
+				'class'  => true,
+				'rel'    => true,
+				'title'  => true,
+				'target' => true,
+				'id'     => true,
+			),
+			'span' => array(
+				'class' => true,
+				'id'    => true,
+			),
+			'svg'  => array(
+				'class'       => true,
+				'xmlns'       => true,
+				'viewbox'     => true,
+				'width'       => true,
+				'height'      => true,
+				'fill'        => true,
+				'aria-hidden' => true,
+			),
+			'path' => array(
+				'd'    => true,
+				'fill' => true,
+			),
+		);
 	}
 
 	/**

--- a/package-plugin.sh
+++ b/package-plugin.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PLUGIN_DIR="markdown-view-for-ai-agents"
+PLUGIN_DIR="returngis-markdown-view-for-ai-agents"
 OUTPUT_DIR="dist"
 OUTPUT_FILE="$OUTPUT_DIR/${PLUGIN_DIR}.zip"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,7 +24,7 @@ cp -R \
   "$SCRIPT_DIR/includes" \
   "$SCRIPT_DIR/LICENSE" \
   "$SCRIPT_DIR/readme.txt" \
-  "$SCRIPT_DIR/markdown-view-for-ai-agents.php" \
+  "$SCRIPT_DIR/returngis-markdown-view-for-ai-agents.php" \
   "$STAGING_DIR/$PLUGIN_DIR/"
 
 ( cd "$STAGING_DIR" && zip -r "$SCRIPT_DIR/$OUTPUT_FILE" "$PLUGIN_DIR" )

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Markdown View for AI Agents">
+<ruleset name="ReturnGIS Markdown View for AI Agents">
   <description>PHP quality and security checks for the plugin.</description>
 
-  <file>markdown-view-for-ai-agents.php</file>
+  <file>returngis-markdown-view-for-ai-agents.php</file>
   <file>includes</file>
 
   <exclude-pattern>vendor/*</exclude-pattern>

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
-=== Markdown View for AI Agents ===
+=== ReturnGIS Markdown View for AI Agents ===
 Contributors: 0gis0
 Tags: markdown, ai, agents, content, export
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ Serve WordPress posts and pages as clean Markdown for AI agents and automation t
 
 == Description ==
 
-Markdown View for AI Agents adds a small button to singular posts and pages so visitors, crawlers, and AI agents can open a clean Markdown version of the content.
+ReturnGIS Markdown View for AI Agents adds a small button to singular posts and pages so visitors, crawlers, and AI agents can open a clean Markdown version of the content.
 
 The same Markdown output is also available programmatically by appending `?format=markdown` to a post or page URL.
 
@@ -35,7 +35,7 @@ Typical use cases:
 
 == Installation ==
 
-1. Upload the `markdown-view-for-ai-agents` folder to the `/wp-content/plugins/` directory, or install the plugin through the WordPress admin.
+1. Upload the `returngis-markdown-view-for-ai-agents` folder to the `/wp-content/plugins/` directory, or install the plugin through the WordPress admin.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Open any published post or page.
 4. Click the "View as Markdown" button, or append `?format=markdown` to the URL.
@@ -64,6 +64,10 @@ Yes. The plugin caches the generated Markdown for 1 hour using WordPress transie
 
 == Upgrade Notice ==
 
+= 1.0.6 =
+
+Addressed WordPress.org review feedback: renamed plugin to ReturnGIS Markdown View for AI Agents, updated slug, and sanitized injected button output.
+
 = 1.0.5 =
 
 Updated compatibility metadata for WordPress 7.0.
@@ -89,6 +93,10 @@ Improved WordPress.org readme content and public plugin metadata.
 Initial public release.
 
 == Changelog ==
+
+= 1.0.6 =
+* addressed WordPress.org review feedback for plugin name, slug, and text domain
+* sanitized button HTML markup returned from `the_content` filter callback using `wp_kses`
 
 = 1.0.5 =
 * updated the `Tested up to` header to WordPress 7.0

--- a/returngis-markdown-view-for-ai-agents.php
+++ b/returngis-markdown-view-for-ai-agents.php
@@ -4,24 +4,24 @@
  *
  * @package MD_For_Agents
  *
- * Plugin Name:       Markdown View for AI Agents
+ * Plugin Name:       ReturnGIS Markdown View for AI Agents
  * Plugin URI:        https://github.com/0GiS0/markdown-view-for-agents
  * Description:       Serve WordPress posts and pages as clean Markdown for AI agents via a button or ?format=markdown.
- * Version:           1.0.5
+ * Version:           1.0.6
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Gisela Torres
  * Author URI:        https://www.returngis.net
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       markdown-view-for-ai-agents
+ * Text Domain:       returngis-markdown-view-for-ai-agents
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'MD_FOR_AGENTS_VERSION', '1.0.5' );
+define( 'MD_FOR_AGENTS_VERSION', '1.0.6' );
 define( 'MD_FOR_AGENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- Renamed plugin to **ReturnGIS Markdown View for AI Agents** (slug/text domain: `returngis-markdown-view-for-ai-agents`).
- Added `wp_kses()` with SVG tag whitelist in `the_content` filter to safely escape injected button markup.
- Bumped version to `1.0.6` in plugin header, constants, and `readme.txt`.
- Updated packaging scripts, devcontainer, tasks, and GitHub Actions release/CI workflows.