### PR TITLE
Update Tested up to header to WordPress 7.1 and bump to 1.0.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: 0gis0
 Tags: markdown, ai, agents, content, export
 Requires at least: 5.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ Yes. The plugin caches the generated Markdown for 1 hour using WordPress transie
 
 == Upgrade Notice ==
 
+= 1.0.7 =
+
+Updated the `Tested up to` header to WordPress 7.1.
+
 = 1.0.6 =
 
 Addressed WordPress.org review feedback: renamed plugin to ReturnGIS Markdown View for AI Agents, updated slug, and sanitized injected button output.
@@ -93,6 +97,9 @@ Improved WordPress.org readme content and public plugin metadata.
 Initial public release.
 
 == Changelog ==
+
+= 1.0.7 =
+* updated the `Tested up to` header to WordPress 7.1
 
 = 1.0.6 =
 * addressed WordPress.org review feedback for plugin name, slug, and text domain

--- a/returngis-markdown-view-for-ai-agents.php
+++ b/returngis-markdown-view-for-ai-agents.php
@@ -7,7 +7,7 @@
  * Plugin Name:       ReturnGIS Markdown View for AI Agents
  * Plugin URI:        https://github.com/0GiS0/markdown-view-for-agents
  * Description:       Serve WordPress posts and pages as clean Markdown for AI agents via a button or ?format=markdown.
- * Version:           1.0.6
+ * Version:           1.0.7
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Gisela Torres
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'MD_FOR_AGENTS_VERSION', '1.0.6' );
+define( 'MD_FOR_AGENTS_VERSION', '1.0.7' );
 define( 'MD_FOR_AGENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MD_FOR_AGENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
### Summary

Update the `Tested up to` header in `readme.txt` to WordPress 7.1 to satisfy the WordPress.org automated plugin scan requirements, and bump the plugin version to 1.0.7.

### Motivation

When submitting the plugin zip to WordPress.org, the automated scanner failed with:
`[ERROR: outdated_tested_upto_header]: Tested up to: 7.0 < 7.1. The "Tested up to" value in your plugin is not set to the current version of WordPress.`

### Changes

- Set `Tested up to: 7.1` in `readme.txt`.
- Bumped `Stable tag` to `1.0.7` in `readme.txt`.
- Added 1.0.7 changelog entry and upgrade notice.
- Bumped plugin header version and `MD_FOR_AGENTS_VERSION` constant to `1.0.7` in `returngis-markdown-view-for-ai-agents.php`.
- Rebuilt `dist/returngis-markdown-view-for-ai-agents.zip`.